### PR TITLE
Update Neo field output

### DIFF
--- a/src/services/BlockUsageService.php
+++ b/src/services/BlockUsageService.php
@@ -57,29 +57,20 @@ class BlockUsageService extends Component
             // Loop over top level Block Types
             /** @var $block BlockType */
             foreach ($field->getBlockTypes() as $block) {
-                // Check it's top level
-                if ($block->topLevel) {
-  
-                    $children = [];
-                    if ($block->childBlocks) {
-                        $children = $this->_getNeoChildBlocks($field->handle, $block->childBlocks);
-                    }
 
-                    $count = Entry::find()
-                        ->neoCriteria($field->handle, [
-                            'type' => $block->handle,
-                        ])
-                        ->count();
-
+                $count = Entry::find()
+                    ->neoCriteria($field->handle, [
+                        'type' => $block->handle,
+                    ])
+                    ->count();
     
-                    $_blocks[] = [
-                        'id' => $block->id,
-                        'handle' => $block->handle,
-                        'name' => $block->name,
-                        'children' => $children,
-                        'count' => $count,
-                    ];
-                }
+                $_blocks[] = [
+                    'id' => $block->id,
+                    'handle' => $block->handle,
+                    'name' => $block->name,
+                    'count' => $count,
+                    'notTopLevel' => !$block->topLevel,
+                ];
             }
         }
   
@@ -131,33 +122,5 @@ class BlockUsageService extends Component
         $ret['entries'] = $entries;
                 
         return $ret;
-    }
-
-    private function _getNeoChildBlocks(string $fieldHandle, array $children, $output = []): array {
-
-        foreach( $children as $child) {
-            $childBlock = \benf\neo\Plugin::$plugin->blockTypes->getByHandle($child);
-
-            if ($childBlock->childBlocks) {
-                $output = $this->_getNeoChildBlocks($fieldHandle, $childBlock->childBlocks, $output);
-            }
-            else {
-
-                $count = Entry::find()
-                    ->neoCriteria($fieldHandle, [
-                        'type' => $childBlock->handle,
-                    ])
-                    ->count();
-                    
-                $output[$child] = [
-                    'id' => $childBlock->id,
-                    'handle' => $childBlock->handle,
-                    'name' => $childBlock->name,
-                    'count' => $count
-                ];
-            }
-        }
-
-        return $output;
     }
 }

--- a/src/templates/index.twig
+++ b/src/templates/index.twig
@@ -80,28 +80,17 @@
                             </thead>
                             <tbody class="vuetable-body">
                                 {% for b in blocks ?? [] %}
+                                    {% set linkStyle = '' %}
+                                    {% if b.notTopLevel is defined and b.notTopLevel %}
+                                        {% set linkStyle = 'margin-left: 1em;' %}
+                                    {% endif %}
 
                                     <tr >
                                         <td>
-                                            <a href="{{ url("block-usage/fields/#{field.id}/#{b.id}") }}">{{ b.name }}</a>
+                                            <a style="{{linkStyle}}" href="{{ url("block-usage/fields/#{field.id}/#{b.id}") }}">{{ b.name }}</a>
                                         </td>
                                         <td>{{ b.count }}</td>
                                     </tr>
-                                    {% if b.children is defined %}
-                                        {% for child in b.children %}
-                                            <tr>
-                                                <td style="display:flex; align-items: center;">
-                                                    <span style="margin-right: .4em; color: #555">
-                                                        <svg style="width: 12px;" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                                                        </svg>
-                                                    </span>
-                                                    <a href="{{ url("block-usage/fields/#{field.id}/#{b.id}") }}">{{ child.name }}</a>
-                                                </td>
-                                                <td>{{ child.count }}</td>
-                                            </tr> 
-                                        {% endfor %}
-                                    {% endif %}
                                 {% endfor %}
                             </tbody>
                         </table>


### PR DESCRIPTION
This fixes #6 and #5 

The handling of Neo blocks with children had some issues. Instead of trying to nest children block types, this PR updates the plugin to display a field's Neo block types in the same way that Neo does - a flat list, with non-top-level block types indented slightly.


### Changes:
- Remove filtering out top-level children
- Remove any attempt to recurse neo block types
- Add `notTopLevel` property to block row
- Update template to display flat list with indented items that have `notTopLevel=true`